### PR TITLE
[WIP] Add support for variable point size in 2D scatter plots

### DIFF
--- a/etc/examples/8.cr
+++ b/etc/examples/8.cr
@@ -1,0 +1,15 @@
+{% if flag?(:png) %}
+  require "../../src/ishi/png"
+{% else %}
+  require "../../src/ishi"
+{% end %}
+
+# Scatter plot with variable circle size.
+Ishi.new do
+  canvas_size(480, 360)
+  n = 10
+  x = (1..n).map { rand }
+  y = (1..n).map { rand }
+  size = (1..n).map { rand * 10 }
+  scatter(x,y, pointsize: size, pt: "o", style: :points)
+end

--- a/src/ishi/gnuplot.cr
+++ b/src/ishi/gnuplot.cr
@@ -219,7 +219,7 @@ module Ishi
       @linewidth : Int32 | Float64 | Nil = nil
       @linestyle : Int32? = nil
       @fillstyle : Int32 | Float64 | Nil = nil
-      @pointsize : Int32 | Float64 | Nil = nil
+      @pointsize : Int32 | Float64 | Array(Float64) | Nil = nil
       @pointtype : Int32 | String | Nil = nil
 
       def initialize(options = nil)
@@ -322,8 +322,13 @@ module Ishi
             io << " lc #{_linecolor}" if @linecolor
             io << " lw #{@linewidth}" if @linewidth
             io << " ls #{@linestyle}" if @linestyle
-            io << " ps #{@pointsize}" if @pointsize
             io << " pt #{_pointtype}" if @pointtype
+            case @pointsize
+            when Array
+              io << " ps var"
+            else
+              io << " ps #{@pointsize}" if @pointsize
+            end
           end
         end
       end
@@ -461,7 +466,7 @@ module Ishi
                      @linecolor : String? = nil,
                      @linewidth : Int32 | Float64 | Nil = nil,
                      @linestyle : Int32? = nil,
-                     @pointsize : Int32 | Float64 | Nil = nil,
+                     @pointsize : Int32 | Float64 | Array(Float64) | Nil = nil,
                      @pointtype : Int32 | String | Nil = nil,
                      **options
                     )
@@ -478,8 +483,15 @@ module Ishi
 
       def data
         Array(String).new.tap do |arr|
-          @xdata.zip(@ydata).each do |x, y|
-            arr << "#{as_scalar(x)} #{as_scalar(y)}"
+          case sizes = @pointsize
+          when Array
+            @xdata.zip(@ydata, sizes).each do |x, y, size|
+              arr << "#{as_scalar(x)} #{as_scalar(y)} #{as_scalar(size)}"
+            end
+          else
+            @xdata.zip(@ydata).each do |x, y|
+              arr << "#{as_scalar(x)} #{as_scalar(y)}"
+            end
           end
           arr << "e"
         end


### PR DESCRIPTION
This is to start a conversation around how we can add support for variable point size in scatter plots.

## Gnuplot
To get variable points size on a 2D gnuplot plot:
* provide a third value past x and y
* set the style to `points` - `dots` is not compatible with variable sizes, for example
* set `ps` to `variable` - or `var`, for short

## References
* http://gnuplot.sourceforge.net/demo_5.0/pointsize.html

## Sample output
![image](https://user-images.githubusercontent.com/782103/79924079-e4c99680-842e-11ea-8981-989dcedbbc6d.png)
